### PR TITLE
Fix support for arm64 Linux identifying as aarch64

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -21,7 +21,7 @@ case "$(uname -s)|$(uname -m)" in
 	"Linux|x86_64")
 		DOWNLOAD_URL="https://github.com/GoogleCloudPlatform/terraformer/releases/download/${ASDF_INSTALL_VERSION}/terraformer-all-linux-amd64"
 		;;
-	"Linux|arm64")
+	"Linux|arm64"|"Linux|aarch64")
 		DOWNLOAD_URL="https://github.com/GoogleCloudPlatform/terraformer/releases/download/${ASDF_INSTALL_VERSION}/terraformer-all-linux-arm64"
 		;;
 esac


### PR DESCRIPTION
Every "arm64" Linux system that I'm aware of returns "aarch64" as the machine type (from `uname -m`).

This PR fixes support for this platform combination, while maintaining compatibility with the original pattern as well, to avoid unknown disruption. 